### PR TITLE
Avoid deadlock due to channel used for disconnect notification

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -27,7 +27,10 @@ const (
 
 func (ae *Exporter) setStateDisconnected() {
 	atomic.StoreInt32(&ae.connectionState, sDisconnected)
-	ae.disconnectedCh <- true
+	select {
+	case ae.disconnectedCh <- true:
+	default:
+	}
 }
 
 func (ae *Exporter) setStateConnected() {


### PR DESCRIPTION
The function setStateDisconnected() writes to the channel disconnectedCh, however, the function indefiniteBackgroundConnection() that reads the channel also calls setStateDisconnected(). If other routine already wrote to the channel indefiniteBackgroundConnection() gets blocked. The fix is just to attempt to write to the channel and proceed if it is already full (capacity is set to 1).