### PR TITLE
Avoid error formating on ExportTraceServiceRequest

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -15,6 +15,7 @@
 package ocagent
 
 import (
+	"fmt"
 	"math/rand"
 	"sync/atomic"
 	"time"
@@ -38,6 +39,7 @@ func (ae *Exporter) saveLastConnectError(err error) {
 }
 
 func (ae *Exporter) setStateDisconnected(err error) {
+	err = fmt.Errorf("no active connection, last connection error: %v", err)
 	ae.saveLastConnectError(err)
 	select {
 	case ae.disconnectedCh <- true:

--- a/ocagent.go
+++ b/ocagent.go
@@ -466,7 +466,7 @@ func (ae *Exporter) exportTraceServiceRequestStream(batch *agenttracepb.ExportTr
 
 	default:
 		if lastConnectErr := ae.lastConnectError(); lastConnectErr != nil {
-			return fmt.Errorf("ExportTraceServiceRequest: no active connection, last connection error: %v", lastConnectErr)
+			return lastConnectErr
 		}
 
 		ae.senderMu.Lock()


### PR DESCRIPTION
This is the hotpath for OC Service.

A0-1163 #comment First step to fix it: have the fix in our gogoproto version, next publish it with a label. 